### PR TITLE
FEATURE - Exclusive multi selection filters

### DIFF
--- a/src/django_admin_multi_select_filter/filters.py
+++ b/src/django_admin_multi_select_filter/filters.py
@@ -133,7 +133,7 @@ class MultiSelectRelatedFieldListFilter(admin.RelatedFieldListFilter):
             }
 
 
-class ExclusiveMultiSelectFilterMixin:
+class ExclusiveMultiSelectRelatedFieldListFilter(MultiSelectRelatedFieldListFilter):
     def queryset(self, request, queryset):
         try:
             if self.lookup_val_isnull:
@@ -155,17 +155,3 @@ class ExclusiveMultiSelectFilterMixin:
 
         except (ValueError, ValidationError) as e:
             raise IncorrectLookupParameters(e)
-
-
-class ExclusiveMultiSelectFieldListFilter(
-    ExclusiveMultiSelectFilterMixin,
-    MultiSelectFieldListFilter,
-):
-    pass
-
-
-class ExclusiveMultiSelectRelatedFieldListFilter(
-    ExclusiveMultiSelectFilterMixin,
-    MultiSelectRelatedFieldListFilter,
-):
-    pass


### PR DESCRIPTION
Created a new filter class ExclusiveMultiSelectRelatedFieldListFilter.

The new class make it possible to filter only objects that match all selections.

e.g.: Model A has an M2M field to Model B.

- Instance A.1 from model A has associations with instances B.1 and instance B.2 from model B.
- Instance A.2 is associated with instances B.2 and B.3.

If the following query is made A.objects.filter(B__in=[2,3]) both instances A.1 and A.2 will return since the __in lookup is inclusive. This is OK in most cases, but if you want to display only objects that match all choices you'd be in trouble.